### PR TITLE
Add import in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ M80_nut    = ISOHexNut("M80")
 
 # Define the gap parameters
 from pyflange.gap import gap_height_distribution
+from math import pi
 D = 7.50                        # meters, flange outer diameter
 gap_angle = pi/6                # 30 deg gap angle
 gap_length = gap_angle * D/2    # outer length of the gap


### PR DESCRIPTION
The instructions on how to use the pyflange package contain a code snippet that does not run because of a missing import.

This is a very minor change, so I did not put in the effort of starting a discussion before creating the PR :)